### PR TITLE
Reset attributes before rendering.

### DIFF
--- a/forks/zbox/src/box.zig
+++ b/forks/zbox/src/box.zig
@@ -61,6 +61,8 @@ pub fn push(buffer: Buffer) (Allocator.Error || ErrorSet.Utf8Encode || ErrorSet.
     try front.resize(buffer.height, buffer.width);
     var row: usize = 0;
 
+    try term.sendSGR(.{});
+
     try term.beginSync();
     while (row < buffer.height) : (row += 1) {
         var col: usize = 0;


### PR DESCRIPTION
This should fixes issues encountered during resize.

Can't really test it with bork, since I am not a streamer, but when I played around with zbox, this patch solved the issue for me.