### PR TITLE
Update Pkg structs to use .source instead of .path

### DIFF
--- a/deps.zig
+++ b/deps.zig
@@ -5,13 +5,13 @@ const FileSource = std.build.FileSource;
 pub const pkgs = struct {
     pub const zbox = Pkg{
         .name = "zbox",
-        .path = FileSource{
+        .source = FileSource{
             .path = "forks/zbox/src/box.zig",
         },
         .dependencies = &[_]Pkg{
             Pkg{
                 .name = "ziglyph",
-                .path = FileSource{
+                .source = FileSource{
                     .path = ".gyro/ziglyph-jecolon-github.com-90ac933a/pkg/src/ziglyph.zig",
                 },
             },
@@ -20,49 +20,49 @@ pub const pkgs = struct {
 
     pub const datetime = Pkg{
         .name = "datetime",
-        .path = FileSource{
+        .source = FileSource{
             .path = ".gyro/zig-datetime-frmdstryr-github.com-9a49593d/pkg/src/datetime.zig",
         },
     };
 
     pub const clap = Pkg{
         .name = "clap",
-        .path = FileSource{
+        .source = FileSource{
             .path = ".gyro/zig-clap-Hejsil-github.com-ac5f4654/pkg/clap.zig",
         },
     };
 
     pub const iguanaTLS = Pkg{
         .name = "iguanaTLS",
-        .path = FileSource{
+        .source = FileSource{
             .path = ".gyro/iguanaTLS-nektro-github.com-9a05f036/pkg/src/main.zig",
         },
     };
 
     pub const hzzp = Pkg{
         .name = "hzzp",
-        .path = FileSource{
+        .source = FileSource{
             .path = ".gyro/hzzp-truemedian-github.com-bf5aaf22/pkg/src/main.zig",
         },
     };
 
     pub const tzif = Pkg{
         .name = "tzif",
-        .path = FileSource{
+        .source = FileSource{
             .path = ".gyro/zig-tzif-leroycep-github.com-cbb1d9f6/pkg/tzif.zig",
         },
     };
 
     pub const ziglyph = Pkg{
         .name = "ziglyph",
-        .path = FileSource{
+        .source = FileSource{
             .path = ".gyro/ziglyph-jecolon-github.com-90ac933a/pkg/src/ziglyph.zig",
         },
     };
 
     pub const @"known-folders" = Pkg{
         .name = "known-folders",
-        .path = FileSource{
+        .source = FileSource{
             .path = ".gyro/known-folders-ziglibs-github.com-9db1b992/pkg/known-folders.zig",
         },
     };
@@ -82,7 +82,7 @@ pub const pkgs = struct {
 pub const exports = struct {
     pub const bork = Pkg{
         .name = "bork",
-        .path = "src/main.zig",
+        .source = "src/main.zig",
         .dependencies = &[_]Pkg{
             pkgs.zbox,
             pkgs.datetime,


### PR DESCRIPTION
When building this with Zig `0.10.0-dev.2562+61844b6bd`, I found that `zig build` gives me:
```
./deps.zig:8:9: error: no member named 'path' in struct 'std.build.Pkg'
        .path = FileSource{
        ^
```
Indeed when looking into docs, it seems it has changed to `.source`. With these changes the project compiles correctly.