### PR TITLE
It seems std.http.Server.init doesn't take an allocator

### DIFF
--- a/src/network/twitch/auth.zig
+++ b/src/network/twitch/auth.zig
@@ -146,7 +146,7 @@ fn authenticateTokenNative(gpa: std.mem.Allocator, token: []const u8) !?Auth {
 }
 
 fn waitForToken(gpa: std.mem.Allocator) ![]const u8 {
-    var server = std.http.Server.init(gpa, .{
+    var server = std.http.Server.init(.{
         .reuse_address = true,
         .reuse_port = true,
     });


### PR DESCRIPTION
Unable to build bork w/ zig 0.12.0-dev.2341+92211135f without this tweak.